### PR TITLE
Add HackNights reference to After Hours section

### DIFF
--- a/src/views/home.tmpl
+++ b/src/views/home.tmpl
@@ -134,9 +134,9 @@
         <div class="bg" data-wide="img/bg/hacknights.jpg" data-narrow="img/bg/support2.jpg" /></div>  
         <h1>Build &amp; Socialize with Cool People</h1>
         <div class="initiative">
-          <h2 class="h3">After Hours</h2>
+          <h2 class="h3">After Hours (formerly HackNights)</h2>
           <p>Designers, developers, and makers of all sorts coming together to hang out, work on their projects and get to know each other. All experience levels welcome!</p>
-          <p>(You&rsquo;ll be notified of relevant Hack Nights events if you&rsquo;re a member of either our <a href="{{channels.Programming.facebook}}">Programming Facebook Group</a> or our <a href="{{ channels.Design.facebook }}">Design Facebook Group</a>.)</p>
+          <p>(You&rsquo;ll be notified of relevant After Hours events if you&rsquo;re a member of either our <a href="{{channels.Programming.facebook}}">Programming Facebook Group</a> or our <a href="{{ channels.Design.facebook }}">Design Facebook Group</a>.)</p>
         </div>
 
         {#


### PR DESCRIPTION
We didn't leave any reference to HackNights in the `After Hours` section, so I added `formerly HackNights)` into the section title. Eventually, we can remove this reference, but we should keep it in for at least this school year so we don't totally lose the brand recognition.

This also fixes the typo in the `you'll be notified ...` paragraph.
