### PR TITLE
Custom 404 Message is Persistent for All Users

### DIFF
--- a/src/server.ls
+++ b/src/server.ls
@@ -110,7 +110,7 @@ app.use(express.static(__dirname + '/public'));
 
 # 404 handler
 app.use((req, res, next) ->
-  if req.url is /^\/apply$/
+  if req.url is /^\/apply/
     res.render("404.tmpl", {customMessage: "Applications are closed :/"} <<< data)
   else res.render("404.tmpl", data)
 )


### PR DESCRIPTION
Custom message is no longer tied to data permanently, fixing the issue. URL Pattern is unchanged as per Abhi's suggestion. Fix for issue #39.
