### PR TITLE
Add SW information to techatnyu.org

### DIFF
--- a/src/public/sass/objects.scss
+++ b/src/public/sass/objects.scss
@@ -208,7 +208,6 @@
   position: fixed;
   z-index: 100;
   top: 4em;
-  left: 0;
   right: 0;
   @include rs((padding: 14px));
 


### PR DESCRIPTION
1. Add Startup Week poster as background splash image when first landing on the site. @abhinayashutosh 
2. Add announcements box with link to nyusw.com site, similar to lexilewtan.com @freialobo 

@ethanresnick @grungerabbit @abhiagar can one of you try these changes on your computer? Look for image problems with the startup week poster and for how to make the announcements box look better.

PR for issue #46 
