### PR TITLE
Adds robots.txt & humans.txt per issue #44

### DIFF
--- a/src/public/humans.txt
+++ b/src/public/humans.txt
@@ -1,0 +1,18 @@
+/* TEAM */
+	Ethan Resnick 		| 	http://www.ethanresnick.com/
+	Abhi Agarwal 		| 	http://www.abhi.co/
+	Bob Gardner			| 	http://www.robert-gardner.com/
+
+/* THANKS */
+	Max Dumas
+	Steve Kaliski		|	http://stevekaliski.com/
+	Iris Yuan
+	Justin de Guzman	|	http://justindeguzman.net/
+	Cheryl Wu			|	http://grungerabbit.com/
+	Terri Burns			|	http://terri.party/
+	Dana Lee			|	http://danagilliann.me/
+	Jason Yao			|	https://jason.yao.global/
+
+/* SITE */
+	Language: English
+	Doctype: HTML5

--- a/src/public/robots.txt
+++ b/src/public/robots.txt
@@ -1,0 +1,12 @@
+User-agent: *
+Disallow: /*.json
+Disallow: /*.json-compact
+Disallow: /*.json-html
+Disallow: /*.xml
+Disallow: /*.rss
+Disallow: /*.i
+Disallow: /*.embed
+Allow: /
+
+User-Agent: bender
+Disallow: /my_shiny_metal_ass


### PR DESCRIPTION
Specifies pages are searchable by all search enginer spiders while disallowing indexing of certain files.

Creates a humans.txt where contributors with 5+ commits are considered part of the team, with everybody else listed as thanks.